### PR TITLE
Add NXDomain response example

### DIFF
--- a/yaml/security_blacklist_cdb.yml
+++ b/yaml/security_blacklist_cdb.yml
@@ -46,6 +46,11 @@ query_rules:
       ips:
         - "127.0.0.1"
         - "::1"
+# or answer with NXDOMAIN
+# where the lua example can use the name NXDomain, yaml needs RCode digit at this moment
+#    action:
+#      type: RCode
+#      rcode: 3
 
   - name: "default rule"
     selector:


### PR DESCRIPTION
NXDomain example in yaml needs rcode digit where lua config example has 'NXDomain'